### PR TITLE
fix build warnings

### DIFF
--- a/molten.c
+++ b/molten.c
@@ -285,7 +285,7 @@ PHP_FUNCTION(molten_curl_exec)
     /* before */
     zval *res;
     char *span_id = NULL;
-    uint64_t entry_time;
+    uint64_t entry_time = 0;
     
     /* build span_id */
     if (PTG(pct).pch.is_sampled == 1) {
@@ -748,7 +748,9 @@ static void frame_destroy(mo_frame_t *frame)
 /* {{{ Build molten frame */
 static void frame_build(mo_frame_t *frame, zend_bool internal, unsigned char type, zend_execute_data *caller, zend_execute_data *ex, zend_op_array *op_array TSRMLS_DC)
 {
-    zval **args;
+#if PHP_VERSION_ID < 70000
+    zval **args = NULL;
+#endif
     zend_function *zf;
 
     /* init */
@@ -768,7 +770,6 @@ static void frame_build(mo_frame_t *frame, zend_bool internal, unsigned char typ
     frame->level = PTG(level);
 
     /* args init */
-    args = NULL;
     frame->arg_count = 0;
     
     /* link to global stack */
@@ -849,9 +850,7 @@ static void frame_build(mo_frame_t *frame, zend_bool internal, unsigned char typ
 #if PHP_VERSION_ID < 70000
     frame->ori_args = args;
 #else
-    int i;
     if (frame->arg_count) {
-        i = 0;
         zval *p = ZEND_CALL_ARG(ex, 1);
         if (ex->func->type == ZEND_USER_FUNCTION) {
             uint32_t first_extra_arg = ex->func->op_array.num_args;


### PR DESCRIPTION
```
/work/GIT/Molten/molten.c: Dans la fonction « frame_build »:
/work/GIT/Molten/molten.c:852:9: attention : variable « i » set but not used [-Wunused-but-set-variable]
     int i;
         ^
/work/GIT/Molten/molten.c:751:12: attention : variable « args » set but not used [-Wunused-but-set-variable]
     zval **args;
            ^~~~
In file included from /usr/include/php/main/php.h:39:0,
                 from /work/GIT/Molten/molten.c:21:

/usr/include/php/Zend/zend_API.h:173:76: attention : « entry_time » may be used uninitialized in this function [-Wmaybe-uninitialized]
 #define ZEND_MODULE_GLOBALS_ACCESSOR(module_name, v) (module_name##_globals.v)
                                                                            ^
/work/GIT/Molten/molten.c:288:14: note : « entry_time » was declared here
     uint64_t entry_time;
              ^~~~~~~~~~

```