### PR TITLE
traceId 分布式系统防止重复

### DIFF
--- a/molten_util.c
+++ b/molten_util.c
@@ -29,6 +29,31 @@
 
 #define MAX_SPANS       65534
 #define MAX_SPANS_LEN   5
+#define MAX_HOST_NAME   10
+
+/*
+ * crc32 code from http://www.hackersdelight.org/hdcodetxt/crc.c.txt
+ */
+unsigned int crc32(unsigned char *message) {
+   int i, crc;
+   unsigned int byte, c;
+   const unsigned int g0 = 0xEDB88320,    g1 = g0>>1,
+      g2 = g0>>2, g3 = g0>>3, g4 = g0>>4, g5 = g0>>5,
+      g6 = (g0>>6)^g0, g7 = ((g0>>6)^g0)>>1;
+
+   i = 0;
+   crc = 0xFFFFFFFF;
+   while ((byte = message[i]) != 0) {    // Get next byte.
+      crc = crc ^ byte;
+      c = ((crc<<31>>31) & g7) ^ ((crc<<30>>31) & g6) ^
+          ((crc<<29>>31) & g5) ^ ((crc<<28>>31) & g4) ^
+          ((crc<<27>>31) & g3) ^ ((crc<<26>>31) & g2) ^
+          ((crc<<25>>31) & g1) ^ ((crc<<24>>31) & g0);
+      crc = ((unsigned)crc >> 8) ^ c;
+      i = i + 1;
+   }
+   return ~crc;
+}
 
 /* rand uini64 */
 uint64_t rand_uint64(void) 
@@ -36,6 +61,9 @@ uint64_t rand_uint64(void)
     uint64_t r = 0;
     int i = 0;
     struct timeval tv;
+    char hostname[MAX_HOST_NAME];
+    int seed = crc32(gethostname(&hostname, MAX_HOST_NAME)) * (gettimeofday(&tv, NULL) == 0 ? tv.tv_usec * getpid() : getpid());
+
     int seed = gettimeofday(&tv, NULL) == 0 ? tv.tv_usec * getpid() : getpid();
     srandom(seed);
     for (i = LOOP_COUNT; i > 0; i--) {


### PR DESCRIPTION
在分布式系统中 traceId 不唯一容易导致瀑布流显示错乱，在随机数中增加了主机名的 crc32 来防止重复