### PR TITLE
Update README.md  add ini_set service_name

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ it is cool, alright?
 
 `molten.enable` set 1 enable or set 0 disable, default `1`.
 
-`molten.service_name` is to set service name for label app service name.
+`molten.service_name` is to set service name for label app service name. now we support add `ini_set('molten.service_name', 'YOUR_PROJECT_NAME'); ` to code to trace different projects using same php enveroment.
 
 `molten.tracing_cli` set `1` to trace, cli sapi, `0` not trace, just use for trace unit test, default `0`.
 

--- a/README_ZH.md
+++ b/README_ZH.md
@@ -63,7 +63,7 @@ sh complex.sh
 
 `molten.enable` 1开启0关闭, 默认 `1`。
 
-`molten.service_name` 设置应用服务名, 默认`default`。
+`molten.service_name` 设置应用服务名, 默认`default`。 现在支持添加 `ini_set('molten.service_name', 'YOUR_PROJECT_NAME'); ` 到代码中来在同一套 PHP 环境中区分不同项目。
 
 `molten.tracing_cli` 1追踪cli模式下信息, 0关闭, 默认`0`。
 


### PR DESCRIPTION
now we support add `ini_set('molten.service_name', 'YOUR_PROJECT_NAME'); ` to code to trace different projects using same php enveroment.