### PR TITLE
feat: Make sink_http_uri settable in php

### DIFF
--- a/molten.c
+++ b/molten.c
@@ -527,6 +527,35 @@ ZEND_INI_MH(molten_update_service_name)
 }
 /* }}} */
 
+/* {{{ molten update sink_http_uri */
+ZEND_INI_MH(molten_update_sink_http_uri)
+{
+#if PHP_VERSION_ID < 70000 
+    if (new_value_length == 0) {
+        return FAILURE;
+    }
+
+    if (OnUpdateString(entry, new_value, new_value_length, mh_arg1, mh_arg2, mh_arg3, stage TSRMLS_CC) == FAILURE) {
+        return FAILURE;
+    }
+    
+    PTG(pcl).post_uri = new_value;
+#else
+    if (ZSTR_LEN(new_value) <= 0) {
+        return FAILURE;
+    }
+
+    if (OnUpdateString(entry, new_value, mh_arg1, mh_arg2, mh_arg3, stage) == FAILURE) {
+         return FAILURE;
+    }
+ 
+    PTG(pcl).post_uri = ZSTR_VAL(new_value);
+#endif
+
+    return SUCCESS;
+}
+/* }}} */
+
 /* {{{ molten_module_entry
 */
 zend_module_entry molten_module_entry = {
@@ -569,7 +598,7 @@ PHP_INI_BEGIN()
     STD_PHP_INI_ENTRY("molten.report_limit",          "100",          PHP_INI_SYSTEM, OnUpdateLong, report_limit, zend_molten_globals, molten_globals)
     STD_PHP_INI_ENTRY("molten.sink_type",             "1",            PHP_INI_SYSTEM, OnUpdateLong, sink_type, zend_molten_globals, molten_globals)
     STD_PHP_INI_ENTRY("molten.output_type",           "1",            PHP_INI_SYSTEM, OnUpdateLong, output_type, zend_molten_globals, molten_globals)
-    STD_PHP_INI_ENTRY("molten.sink_http_uri",         "",             PHP_INI_SYSTEM, OnUpdateString, sink_http_uri, zend_molten_globals, molten_globals)
+    STD_PHP_INI_ENTRY("molten.sink_http_uri",         "",             PHP_INI_ALL,    molten_update_sink_http_uri, sink_http_uri, zend_molten_globals, molten_globals)
     STD_PHP_INI_ENTRY("molten.sink_syslog_unix_socket", "",           PHP_INI_SYSTEM, OnUpdateString, sink_syslog_unix_socket, zend_molten_globals, molten_globals)
     STD_PHP_INI_ENTRY("molten.sink_kafka_brokers",    "",             PHP_INI_SYSTEM, OnUpdateString, sink_kafka_brokers, zend_molten_globals, molten_globals)
     STD_PHP_INI_ENTRY("molten.sink_kafka_topic",      "",             PHP_INI_SYSTEM, OnUpdateString, sink_kafka_topic, zend_molten_globals, molten_globals)


### PR DESCRIPTION
## 0x00 Purpose
When we have multi environment, such as `Development` or `Production`, we want to use different `jaeger`/`zipkin` for tracing, so this feature will let you make it!

## 0x01 Usage
```php
ini_set('molten.sink_http_uri', 'http://127.0.0.1:9411/api/v1/spans')
```

## 0x02 Example
```shell
php -d extension=molten.so -d molten.enable=1 -d molten.open_report=1 -d molten.span_format="zipkin" -d molten.sink_type=4 -d molten.tracing_cli=1 -d molten.sampling_rate=1 -r 'ini_set("molten.service_name", "this_is_my_service");ini_set("molten.sink_http_uri", "http://127.0.0.1:9411/api/v1/spans");$c=curl_init("http://localhost:12345");curl_exec($c);'
```
